### PR TITLE
install_mt4-xdot.sh: fix installer's downloader

### DIFF
--- a/scripts/install_mt4-xdot.sh
+++ b/scripts/install_mt4-xdot.sh
@@ -3,6 +3,7 @@
 CWD="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 DTMP=$(mktemp -d)
 EXEFILE=mt4setup.exe
+WURL="https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks"
 export WINEDLLOVERRIDES="mscoree,mshtml=,winebrowser.exe="
 
 # Check the dependencies.
@@ -10,6 +11,9 @@ type wget xdotool xwininfo wine ar >&2
 
 # Load the shell functions.
 . "$CWD/.funcs.inc.sh"
+
+echo "Installing winhttp..." >&2
+sh -s winhttp < <(wget -qO- $WURL)
 
 echo "Downloading MT4 installer..." >&2
 [ ! -f "$HOME/$EXEFILE" ] \

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -57,7 +57,7 @@ case "$(uname -s)" in
     fi
 
     # Add PPA/Wine repository
-    apt-get install -qy python-software-properties                                # APT dependencies (required for the add-apt-repository command on Ubuntu).
+    apt-get install -qy software-properties-common                                # APT dependencies (required for the add-apt-repository command on Ubuntu).
     curl -s https://dl.winehq.org/wine-builds/Release.key | apt-key add -         # Adds GPG release key.
     add-apt-repository -y \
       "deb https://dl.winehq.org/wine-builds/ubuntu/ ${codename:-trusty} main"    # Adds APT Wine repository.
@@ -67,7 +67,7 @@ case "$(uname -s)" in
 
     # Install necessary packages
     apt-get install -qy language-pack-en                                          # Language pack to prevent an invalid locale.
-    apt-get install -qy python-software-properties                                # APT dependencies (required for a docker image).
+    apt-get install -qy software-properties-common                                # APT dependencies (required for a docker image).
     apt-get install -qy binutils coreutils moreutils cabextract zip unzip         # Common CLI utils.
     apt-get install -qy imagemagick                                               # ImageMagick.
     apt-get install -qy dbus                                                      # Required for Debian AMI on EC2.


### PR DESCRIPTION
This should resolve the issues with the installer's downloader, but it still need the workaround for the download hanging. It appears to complete if the installer is exited through the GUI and then restarted multiple times until the download manages to finish. See #113.